### PR TITLE
create dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/devcontainers/rust
+RUN apt-get update
+RUN apt-get install -y git z3 nodejs npm

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+	// dev container
+	"name": "UnKODUS Dev",
+	"build": {
+		"dockerfile": "Dockerfile",
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": []
+		}
+	},
+	"forwardPorts": [
+		3000
+	],
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+    "recommendations": [
+        "serayuzgur.crates",
+        "rust-lang.rust-analyzer",
+        "dbaeumer.vscode-eslint",
+        "christian-kohler.npm-intellisense",
+        "christian-kohler.path-intellisense"
+    ]
+}


### PR DESCRIPTION
due to issues being had with z3 and stuff i think that having a standardized dev environment would be helpful. this adds a devcontainer for use in VSCode (which also includes a raw dockerfile if desired) so that we have one consistent target